### PR TITLE
single template lookup

### DIFF
--- a/aura/FlowEmailComposer/FlowEmailComposerController.js
+++ b/aura/FlowEmailComposer/FlowEmailComposerController.js
@@ -9,6 +9,7 @@
         var whatId = component.get('v.whatId');
         var whoId = component.get('v.whoId');
         var action = component.get('c.getEmailTemplates');
+        var hideTemplateSelection = component.get('v.hideTemplateSelection');
         
         if($A.util.isEmpty(whatId) && $A.util.isEmpty(whoId)){
             component.set('v.uploadRefId', $A.get("$SObjectType.CurrentUser.Id"));
@@ -17,10 +18,15 @@
         }else if(!($A.util.isEmpty(whoId))){
             component.set('v.uploadRefId', whoId);
         }
+        if(hideTemplateSelection){ //if we are hiding the template selection boxes, we only need to query the template we are actively using
+            action.setParams({
+                "templateId" : templateId
+            });            
+        }
         action.setCallback(this, function(response){
             var state = response.getState();
             if (state === "SUCCESS") {
-                var templates = response.getReturnValue();
+                var templates = response.getReturnValue();                
                 var folders = [];
                 templates.forEach(function(template, index){
                     let existingFolders = [];

--- a/classes/FlowEmailComposerCtrl.cls
+++ b/classes/FlowEmailComposerCtrl.cls
@@ -1,8 +1,16 @@
 global with sharing class FlowEmailComposerCtrl {
     @AuraEnabled 
-    public static List<EmailTemplate> getEmailTemplates(){
+    public static List<EmailTemplate> getEmailTemplates(string templateId){
         if(Schema.sObjectType.EmailTemplate.isAccessible() && Schema.sObjectType.Attachment.isAccessible()){
             
+            if(string.isNotBlank(templateId)){ //if we are hiding the template selection boxes, we only need to query the template we are actively using
+                return new List<EmailTemplate>([SELECT Subject,Id, Name,DeveloperName, FolderId, Folder.DeveloperName, Folder.Name,
+                        (Select Id,Name from Attachments)
+                    FROM EmailTemplate
+                    WHERE id = :templateId AND TemplateType IN ('custom','text','html')
+                    LIMIT 1]);
+            }
+
             return new List<EmailTemplate>([SELECT Subject,Id, Name,DeveloperName, FolderId, Folder.DeveloperName, Folder.Name,
                 	   (Select Id,Name from Attachments)
                 FROM EmailTemplate

--- a/classes/FlowEmailComposerCtrlTest.cls
+++ b/classes/FlowEmailComposerCtrlTest.cls
@@ -11,10 +11,16 @@ public class FlowEmailComposerCtrlTest {
     }
     static testmethod void testgetEmailTemplates(){
         EmailTemplate e = new EmailTemplate (developerName = 'test', folderid=userinfo.getUserId(),TemplateType= 'Text', Name = 'test'); // plus any other fields that you want to set
+        EmailTemplate e2 = new EmailTemplate (developerName = 'test2', folderid=userinfo.getUserId(),TemplateType= 'Text', Name = 'test2');
         insert e;
-        List<EmailTemplate> emailTemplateList = FlowEmailComposerCtrl.getEmailTemplates();
+        insert e2;
+        List<EmailTemplate> emailTemplateList = FlowEmailComposerCtrl.getEmailTemplates('');
+        List<EmailTemplate> emailTemplateListSingle = FlowEmailComposerCtrl.getEmailTemplates(e.id);
         system.assert(emailTemplateList.size() > 0);
+        system.assert(emailTemplateListSingle.size() == 1);        
         system.assert(FlowEmailComposerCtrl.getTemplateDetails([select id from emailtemplate limit 1].id,null,null) != null);
+        
+        
     }
     static testmethod void testdeleteFiles(){
         List<ContentVersion> cvList = [SELECT Id, Title, ContentDocumentId FROM ContentVersion];


### PR DESCRIPTION
I found that when using this flow in an org with ~1,000 email templates, it was taking 10+ seconds for the template selection inputs to be queried and built on the page, even though I was using the "Hide E-mail Template Selection" option, and so they were not visible or accessible to the user.

Could probably do something cool with lazy loading the entries (maybe by folder and with a max batch size?), but I just added a simple check so that when the `hideTemplateSelection` option is true, it refines the SOQL to only return the single template in question, which solves the problem in my use case.