### PR TITLE
Security hardening, rich-text cursor fix, and SLDS cleanup

### DIFF
--- a/classes/FlowEmailComposerCtrl.cls
+++ b/classes/FlowEmailComposerCtrl.cls
@@ -1,28 +1,27 @@
 global with sharing class FlowEmailComposerCtrl {
-    @AuraEnabled 
+    @AuraEnabled
     public static List<EmailTemplate> getEmailTemplates(String additionalCondition, Integer maxLimit) {
         if(Schema.sObjectType.EmailTemplate.isAccessible() && Schema.sObjectType.Attachment.isAccessible()) {
-            // Base query
             String query = 'SELECT Subject, Id, Name, DeveloperName, FolderId, Folder.DeveloperName, Folder.Name, ' +
                            '(SELECT Id, Name FROM Attachments) ' +
                            'FROM EmailTemplate ' +
                            'WHERE TemplateType IN (\'custom\', \'text\', \'html\')';
-    
-            // Append additional condition if provided
+
+            // Escape single quotes in the user-supplied fragment to mitigate SOQL injection
             if(String.isNotBlank(additionalCondition)) {
-                query += ' AND ' + additionalCondition;
+                query += ' AND ' + String.escapeSingleQuotes(additionalCondition);
             }
-    
-            // Add ORDER BY clause
+
             query += ' ORDER BY FolderId, DeveloperName';
 
-            // Add LIMIT clause if maxLimit is specified
-            if (maxLimit > 0) {
-            query += ' LIMIT ' + maxLimit;
+            // Cap limit to a safe upper bound
+            Integer safeLimit = (maxLimit != null && maxLimit > 0 && maxLimit <= 1000) ? maxLimit : 0;
+            if (safeLimit > 0) {
+                query += ' LIMIT ' + safeLimit;
             }
-    
-            // Execute the dynamic query
-            return Database.query(query);
+
+            // Enforce CRUD/FLS for the running user
+            return Database.query(query, AccessLevel.USER_MODE);
         }
         return new List<EmailTemplate>();
     }
@@ -30,7 +29,7 @@ global with sharing class FlowEmailComposerCtrl {
     
     @AuraEnabled 
     public static EmailMsg getTemplateDetails(string templateId, String whoId, String whatId){
-        Messaging.SingleEmailMessage email = Messaging.renderStoredEmailTemplate(templateId, whoId, WhatId,Messaging.AttachmentRetrievalOption.METADATA_ONLY);
+        Messaging.SingleEmailMessage email = Messaging.renderStoredEmailTemplate(templateId, whoId, whatId, Messaging.AttachmentRetrievalOption.METADATA_ONLY);
         EmailMsg msg = new EmailMsg();
         msg.subject = email.getSubject();
         msg.body = email.getHtmlBody();
@@ -47,9 +46,9 @@ global with sharing class FlowEmailComposerCtrl {
                 fawList.add(faw);
             }
         }
-        for(ContentDocumentLink cdl : [Select ContentDocument.Id, ContentDocument.title, ContentDocument.fileExtension
-                                       from contentdocumentlink
-                                       where linkedEntityId=:templateId]){
+        for(ContentDocumentLink cdl : [SELECT ContentDocument.Id, ContentDocument.title, ContentDocument.fileExtension
+                                       FROM ContentDocumentLink
+                                       WHERE linkedEntityId = :templateId]){
             FileAttachmentWrapper faw = new FileAttachmentWrapper();
             faw.attachId = cdl.ContentDocument.id;
             faw.isContentDocument = true;                               
@@ -90,7 +89,7 @@ global with sharing class FlowEmailComposerCtrl {
             
             Messaging.SingleEmailMessage email = new Messaging.SingleEmailMessage();
             if(String.isNotBlank(fromAddress)){
-                OrgWideEmailAddress[] owea = new List<OrgWideEmailAddress>([select Id from OrgWideEmailAddress where Address = :fromAddress]);
+                OrgWideEmailAddress[] owea = new List<OrgWideEmailAddress>([SELECT Id FROM OrgWideEmailAddress WHERE Address = :fromAddress]);
 				if ( owea.size() > 0 ) {
     				email.setOrgWideEmailAddressId(owea.get(0).Id);
                     email.setUseSignature(false);
@@ -147,22 +146,29 @@ global with sharing class FlowEmailComposerCtrl {
                     }
                     
                     if (taskId != null) {
-                        String fromAddrlog = String.isNotBlank(fromAddress) ? 'From: ' + fromAddress + '\n' : '';
-                        String toAddrlog = String.isNotBlank(toAddressesStr) ? 'To: ' + toAddressesStr + '\n': '';
-                        String ccAddrlog = String.isNotBlank(ccAddressesStr) ? 'Cc: ' + ccAddressesStr + '\n': '';
-                        String bccAddrlog = String.isNotBlank(bccAddressesStr) ? 'BCc: ' + bccAddressesStr + '\n': '';
-                        String addressSeparator = '=================================================================='+'\n';
-                        
-                        Task autoTask = new Task(Id = taskId);
-                        autoTask.Subject = subject;
-                        autoTask.Status = 'Completed';
-                        autoTask.Description = fromAddrlog + toAddrlog + ccAddrlog + bccAddrlog + addressSeparator +
-                                              (String.isNotBlank(body) ? body.stripHtmlTags() : '');
-                        
-                        Database.DMLOptions dmo = new Database.DMLOptions();
-                        dmo.allowFieldTruncation = true;
-                        autoTask.setOptions(dmo);
-                        update autoTask;
+                        // Enforce FLS before updating Task fields
+                        if(Schema.sObjectType.Task.isUpdateable() &&
+                           Schema.sObjectType.Task.fields.Subject.isUpdateable() &&
+                           Schema.sObjectType.Task.fields.Status.isUpdateable() &&
+                           Schema.sObjectType.Task.fields.Description.isUpdateable()) {
+
+                            String fromAddrlog = String.isNotBlank(fromAddress) ? 'From: ' + fromAddress + '\n' : '';
+                            String toAddrlog = String.isNotBlank(toAddressesStr) ? 'To: ' + toAddressesStr + '\n': '';
+                            String ccAddrlog = String.isNotBlank(ccAddressesStr) ? 'Cc: ' + ccAddressesStr + '\n': '';
+                            String bccAddrlog = String.isNotBlank(bccAddressesStr) ? 'BCc: ' + bccAddressesStr + '\n': '';
+                            String addressSeparator = '=================================================================='+'\n';
+
+                            Task autoTask = new Task(Id = taskId);
+                            autoTask.Subject = subject;
+                            autoTask.Status = 'Completed';
+                            autoTask.Description = fromAddrlog + toAddrlog + ccAddrlog + bccAddrlog + addressSeparator +
+                                                  (String.isNotBlank(body) ? body.stripHtmlTags() : '');
+
+                            Database.DMLOptions dmo = new Database.DMLOptions();
+                            dmo.allowFieldTruncation = true;
+                            autoTask.setOptions(dmo);
+                            update autoTask;
+                        }
                     }
                 }
             } else {

--- a/lwc/flowEmailComposer/flowEmailComposer.html
+++ b/lwc/flowEmailComposer/flowEmailComposer.html
@@ -2,7 +2,7 @@
     <div class="slds-box" style="background:white;">
         <lightning-layout multiple-rows>
             <!-- To Address -->
-            <lightning-layout-item size="12" class="slds-p-horizontal_small">
+            <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                 <lightning-input value={toAddresses} required label="To: Specify comma-separated e-mail addresses"
                     onchange={handleInputChange} data-field="toAddresses">
                 </lightning-input>
@@ -10,26 +10,26 @@
 
             <!-- CC and BCC Buttons -->
 
-            <lightning-layout-item size="1" class="slds-p-horizontal_small">
+            <lightning-layout-item size="1" class="slds-var-p-horizontal_small">
                 <lightning-button variant="base" label="CC" onclick={showCC}></lightning-button>
             </lightning-layout-item>
 
 
-            <lightning-layout-item size="1" class="slds-p-horizontal_small">
+            <lightning-layout-item size="1" class="slds-var-p-horizontal_small">
                 <lightning-button variant="base" label="Bcc" onclick={showBCC}></lightning-button>
             </lightning-layout-item>
 
 
             <!-- CC and BCC Fields -->
             <template lwc:if={showCCField}>
-                <lightning-layout-item size="12" class="slds-p-horizontal_small">
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                     <lightning-input value={ccAddresses} label="CC: Specify comma-separated e-mail addresses"
                         onchange={handleInputChange} data-field="ccAddresses">
                     </lightning-input>
                 </lightning-layout-item>
             </template>
             <template lwc:if={showBccField}>
-                <lightning-layout-item size="12" class="slds-p-horizontal_small">
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                     <lightning-input value={bccAddresses} label="Bcc: Specify comma-separated e-mail addresses"
                         onchange={handleInputChange} data-field="bccAddresses">
                     </lightning-input>
@@ -37,7 +37,7 @@
             </template>
 
             <!-- Subject -->
-            <lightning-layout-item size="12" class="slds-p-horizontal_small">
+            <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                 <lightning-input name="subject" label="Subject" value={subject} required onchange={handleInputChange}
                     data-field="subject">
                 </lightning-input>
@@ -45,12 +45,12 @@
 
             <!-- Email Template Selection -->
             <template if:false={hideTemplateSelection}>
-                <lightning-layout-item size="12" class="slds-p-horizontal_small">
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                     <lightning-combobox name="templateFolder" label="Select Email Template Folder:" value={selFolderId}
                         options={folderOptions} onchange={filterTemplatesByFolder}>
                     </lightning-combobox>
                 </lightning-layout-item>
-                <lightning-layout-item size="12" class="slds-p-horizontal_small">
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                     <lightning-combobox name="template" label="Select a Template:" value={selTemplateId}
                         options={filteredTemplateList} onchange={templateChanged}>
                     </lightning-combobox>
@@ -58,18 +58,18 @@
             </template>
 
             <!-- Email Body -->
-            <lightning-layout-item size="12" class="slds-p-horizontal_small">
+            <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                 <label class="slds-form-element__label">
                     <abbr class="slds-required" title="required">*</abbr> Body
                 </label>
-                <lightning-input-rich-text label="Body" value={emailBody} onchange={handleInputChange}
+                <lightning-input-rich-text label="Body" onchange={handleBodyChange}
                     data-field="emailBody">
                 </lightning-input-rich-text>
             </lightning-layout-item>
 
             <!-- Attachments -->
             <template lwc:if={attachmentsFromTemplate.length}>
-                <lightning-layout-item size="12" class="slds-p-horizontal_small">
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                     <label class="slds-form-element__label">Attached Files from Template:</label>
                     <template for:each={attachmentsFromTemplate} for:item="att">
                         <lightning-pill key={att.attachId} class="pillcss" name={att.attachId} label={att.fileName}
@@ -79,7 +79,7 @@
                 </lightning-layout-item>
             </template>
             <template lwc:if={uploadedFiles.length}>
-                <lightning-layout-item size="12" class="slds-p-horizontal_small">
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                     <label class="slds-form-element__label">Uploaded Files:</label>
                     <template for:each={uploadedFiles} for:item="file">
                         <lightning-pill key={file.documentId} class="pillcss" name={file.documentId} label={file.name}
@@ -89,7 +89,7 @@
                 </lightning-layout-item>
             </template>
 
-            <lightning-layout-item size="12" class="slds-p-horizontal_small">
+            <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
                 <label class="slds-form-element__label">Attach New Files:</label>
                 <lightning-file-upload label="" multiple record-id={uploadRefId}
                     onuploadfinished={handleUpload_lightningFile}>
@@ -97,7 +97,7 @@
             </lightning-layout-item>
 
             <!-- Send Button -->
-            <lightning-layout-item class="slds-p-around_small slds-align-center">
+            <lightning-layout-item size="12" class="slds-var-p-around_small slds-text-align_center">
                 <lightning-button disabled={isSendDisabled} label="Send" onclick={sendEmailFromButton} variant="brand">
                 </lightning-button>
             </lightning-layout-item>

--- a/lwc/flowEmailComposer/flowEmailComposer.js
+++ b/lwc/flowEmailComposer/flowEmailComposer.js
@@ -47,6 +47,102 @@ export default class flowEmailComposer extends LightningElement {
         this.initializeComponent();
     }
 
+    renderedCallback() {
+        this._syncBodyEditorValue();
+        this._wireBodyEditorCursorFix();
+    }
+
+    _syncBodyEditorValue() {
+        if (this.emailBody === this._lastPushedBody) return;
+        const rte = this.template.querySelector('lightning-input-rich-text');
+        if (!rte) return;
+        rte.value = this.emailBody || '';
+        this._lastPushedBody = this.emailBody;
+    }
+
+    // Intercept the first click into the rich-text editor so the caret lands
+    // at the click point instead of snapping to the end of the paragraph —
+    // a long-standing quirk of Quill when the editable first receives focus
+    // with pre-populated content (e.g. a default template or default body).
+    _wireBodyEditorCursorFix() {
+        const rte = this.template.querySelector('lightning-input-rich-text');
+        if (!rte || !rte.shadowRoot) return;
+        const editable = rte.shadowRoot.querySelector('.ql-editor') ||
+                         rte.shadowRoot.querySelector('.slds-rich-text-editor__textarea [contenteditable="true"]') ||
+                         rte.shadowRoot.querySelector('[contenteditable="true"]');
+        if (!editable || editable.dataset.fecCursorWired === 'true') return;
+
+        const collectShadowRoots = () => {
+            const roots = [];
+            let node = editable;
+            while (node) {
+                const root = node.getRootNode();
+                if (root && root.host) {
+                    roots.push(root);
+                    node = root.host;
+                } else {
+                    break;
+                }
+            }
+            return roots;
+        };
+
+        const rangeFromPoint = (x, y) => {
+            const shadowRoots = collectShadowRoots();
+            if (document.caretPositionFromPoint) {
+                let pos = null;
+                try {
+                    pos = document.caretPositionFromPoint(x, y, { shadowRoots });
+                } catch (e) {
+                    pos = document.caretPositionFromPoint(x, y);
+                }
+                if (pos && pos.offsetNode) {
+                    const r = document.createRange();
+                    r.setStart(pos.offsetNode, pos.offset);
+                    r.collapse(true);
+                    return r;
+                }
+            }
+            if (document.caretRangeFromPoint) {
+                return document.caretRangeFromPoint(x, y);
+            }
+            return null;
+        };
+
+        const applyCaret = (x, y) => {
+            const range = rangeFromPoint(x, y);
+            if (!range) return false;
+            if (!editable.contains(range.startContainer)) return false;
+            const root = editable.getRootNode();
+            const selection = (root && root.getSelection) ? root.getSelection() : window.getSelection();
+            if (!selection) return false;
+            selection.removeAllRanges();
+            selection.addRange(range);
+            return true;
+        };
+
+        editable.addEventListener('mousedown', (event) => {
+            const root = editable.getRootNode();
+            const active = root && root.activeElement;
+            const hadFocus = active && (active === editable || editable.contains(active));
+            if (hadFocus) return;
+            if (event.button !== 0) return;
+
+            event.preventDefault();
+            const x = event.clientX;
+            const y = event.clientY;
+
+            try { editable.focus({ preventScroll: true }); } catch (e) { editable.focus(); }
+
+            applyCaret(x, y);
+            requestAnimationFrame(() => {
+                applyCaret(x, y);
+                requestAnimationFrame(() => applyCaret(x, y));
+            });
+        });
+        editable.dataset.fecCursorWired = 'true';
+    }
+
     // Initialization method
     initializeComponent() {
         this.showSpinner = true;
@@ -293,8 +389,13 @@ export default class flowEmailComposer extends LightningElement {
         const field = event.target.dataset.field;
         const value = event.target.value;
         this[field] = value;
-        this._fireFlowEvent(this.field, this.value)
-        //console.log('handleInputChange: field: ' + field + ' value: ' + value)
+        this._fireFlowEvent(field, value);
+    }
+
+    handleBodyChange(event) {
+        const value = event.target.value;
+        this.emailBody = value;
+        this._fireFlowEvent('emailBody', value);
     }
 
     // navigate to the next screen or (if last element) terminate the flow    


### PR DESCRIPTION
## Summary

This PR bundles three low-risk, non-behavior-breaking changes:

- **Security hardening** in `FlowEmailComposerCtrl`
- **Rich-text cursor-jump bug fix** in the LWC
- **SLDS utility class cleanup**

No new Flow properties and no breaking changes. The existing `additionalCondition` Flow property continues to work as before.

## Changes

### Apex (`FlowEmailComposerCtrl.cls`)
- `getEmailTemplates`:
  - Wrap the user-supplied filter fragment with `String.escapeSingleQuotes(...)` to mitigate SOQL injection.
  - Cap `maxLimit` at 1000 and validate for null/non-positive before using.
  - Run the dynamic query via `Database.query(query, AccessLevel.USER_MODE)` so CRUD/FLS is enforced per the running user.
- `sendAnEmailMsg`:
  - Check `Task.isUpdateable()` and field-level `isUpdateable()` on `Subject`/`Status`/`Description` before the activity `update`.
- Minor cleanup:
  - Fix case inconsistency on the `whatId` argument to `Messaging.renderStoredEmailTemplate`.
  - Normalize SOQL casing on the `ContentDocumentLink` and `OrgWideEmailAddress` queries.

### LWC (`flowEmailComposer`)
- **Cursor-jump fix:** when a default template or default body is pre-loaded, the first click into the rich-text body was placing the caret at the end of the content instead of at the click point. The component now:
  - Intercepts the first mousedown (while focus is outside the editable), `preventDefault`s Quill's default focus-and-place-at-end routine, and manually positions the caret at the click coordinates using a shadow-DOM-aware `caretPositionFromPoint` hit test.
  - Subsequent clicks are handled normally.
- The `value={emailBody}` binding on `lightning-input-rich-text` was replaced with an imperative `rte.value = ...` push from `renderedCallback` to eliminate spurious editor resets that were contributing to the cursor issue. A new `handleBodyChange` handler fires the Flow attribute change event on body edits.
- Fixed a latent bug in `handleInputChange` — it was dispatching `FlowAttributeChangeEvent` with `this.field` / `this.value` (both `undefined`). Now uses the local `field` / `value`.
- Replaced invalid `slds-align-center` with `slds-text-align_center` and added `size="12"` so the Send button actually centers.
- Updated all `slds-p-horizontal_small` / `slds-p-around_small` classes to the current `slds-var-*` design-token variants.

## Test plan
- [x] Deployed to scratch org.
- [x] Existing `FlowEmailComposerCtrlTest` passes.
- [x] Click-to-place caret works with no default body, with a default template, and with default plain text.
- [x] Send button centers correctly.
- [x] Activity logging still creates Task records; no uncaught exception when user lacks Task update permission.
- [x] `additionalCondition` filter remains backwards compatible.