### PR TITLE
Add Flow properties for labels, help text, folder filter, and UI toggles

### DIFF
--- a/classes/FlowEmailComposerCtrl.cls
+++ b/classes/FlowEmailComposerCtrl.cls
@@ -1,26 +1,27 @@
 global with sharing class FlowEmailComposerCtrl {
-    @AuraEnabled
-    public static List<EmailTemplate> getEmailTemplates(String additionalCondition, Integer maxLimit) {
+    @AuraEnabled 
+    public static List<EmailTemplate> getEmailTemplates(String folderIdFilter, Integer maxLimit) {
         if(Schema.sObjectType.EmailTemplate.isAccessible() && Schema.sObjectType.Attachment.isAccessible()) {
+            // Base query - uses bind variables for user input (SOQL injection safe)
+            // USER_MODE enforces CRUD/FLS per security review requirements
             String query = 'SELECT Subject, Id, Name, DeveloperName, FolderId, Folder.DeveloperName, Folder.Name, ' +
                            '(SELECT Id, Name FROM Attachments) ' +
                            'FROM EmailTemplate ' +
                            'WHERE TemplateType IN (\'custom\', \'text\', \'html\')';
-
-            // Escape single quotes in the user-supplied fragment to mitigate SOQL injection
-            if(String.isNotBlank(additionalCondition)) {
-                query += ' AND ' + String.escapeSingleQuotes(additionalCondition);
+    
+            // Append folder filter using bind variable - no string concatenation of user input
+            if(String.isNotBlank(folderIdFilter)) {
+                query += ' AND FolderId = :folderIdFilter';
             }
-
+    
             query += ' ORDER BY FolderId, DeveloperName';
 
-            // Cap limit to a safe upper bound
+            // LIMIT uses Integer (type-safe); validate range to prevent abuse
             Integer safeLimit = (maxLimit != null && maxLimit > 0 && maxLimit <= 1000) ? maxLimit : 0;
             if (safeLimit > 0) {
                 query += ' LIMIT ' + safeLimit;
             }
-
-            // Enforce CRUD/FLS for the running user
+    
             return Database.query(query, AccessLevel.USER_MODE);
         }
         return new List<EmailTemplate>();
@@ -146,24 +147,24 @@ global with sharing class FlowEmailComposerCtrl {
                     }
                     
                     if (taskId != null) {
-                        // Enforce FLS before updating Task fields
-                        if(Schema.sObjectType.Task.isUpdateable() &&
+                        // Check Field Level Security (FLS) before updating Task fields
+                        if(Schema.sObjectType.Task.isUpdateable() && 
                            Schema.sObjectType.Task.fields.Subject.isUpdateable() &&
                            Schema.sObjectType.Task.fields.Status.isUpdateable() &&
                            Schema.sObjectType.Task.fields.Description.isUpdateable()) {
-
+                            
                             String fromAddrlog = String.isNotBlank(fromAddress) ? 'From: ' + fromAddress + '\n' : '';
                             String toAddrlog = String.isNotBlank(toAddressesStr) ? 'To: ' + toAddressesStr + '\n': '';
                             String ccAddrlog = String.isNotBlank(ccAddressesStr) ? 'Cc: ' + ccAddressesStr + '\n': '';
                             String bccAddrlog = String.isNotBlank(bccAddressesStr) ? 'BCc: ' + bccAddressesStr + '\n': '';
                             String addressSeparator = '=================================================================='+'\n';
-
+                            
                             Task autoTask = new Task(Id = taskId);
                             autoTask.Subject = subject;
                             autoTask.Status = 'Completed';
                             autoTask.Description = fromAddrlog + toAddrlog + ccAddrlog + bccAddrlog + addressSeparator +
                                                   (String.isNotBlank(body) ? body.stripHtmlTags() : '');
-
+                            
                             Database.DMLOptions dmo = new Database.DMLOptions();
                             dmo.allowFieldTruncation = true;
                             autoTask.setOptions(dmo);

--- a/classes/FlowEmailComposerCtrlTest.cls
+++ b/classes/FlowEmailComposerCtrlTest.cls
@@ -70,14 +70,17 @@ public class FlowEmailComposerCtrlTest {
     }
 
     @isTest
-    static void testGetEmailTemplates_WithFilter() {
+    static void testGetEmailTemplates_WithFolderIdFilter() {
+        EmailTemplate et = [SELECT FolderId FROM EmailTemplate WHERE DeveloperName = 'test_text_template' LIMIT 1];
+        Id folderId = et.FolderId;
         Test.startTest();
-        String condition = 'DeveloperName = \'test_text_template\'';
-        List<EmailTemplate> results = FlowEmailComposerCtrl.getEmailTemplates(condition, 0);
+        List<EmailTemplate> results = FlowEmailComposerCtrl.getEmailTemplates(folderId, 0);
         Test.stopTest();
         
-        System.assertEquals(1, results.size(), 'Should return exactly 1 filtered template');
-        System.assertEquals('test_text_template', results[0].DeveloperName);
+        System.assert(results.size() >= 2, 'Should return templates in the specified folder');
+        for (EmailTemplate t : results) {
+            System.assertEquals(folderId, t.FolderId, 'All results should be from the filtered folder');
+        }
     }
 
     @isTest

--- a/lwc/flowEmailComposer/flowEmailComposer.html
+++ b/lwc/flowEmailComposer/flowEmailComposer.html
@@ -3,7 +3,9 @@
         <lightning-layout multiple-rows>
             <!-- To Address -->
             <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                <lightning-input value={toAddresses} required label="To: Specify comma-separated e-mail addresses"
+                <lightning-input value={toAddresses} required
+                    label={resolvedToLabel}
+                    field-level-help={toHelpText}
                     onchange={handleInputChange} data-field="toAddresses">
                 </lightning-input>
             </lightning-layout-item>
@@ -23,14 +25,18 @@
             <!-- CC and BCC Fields -->
             <template lwc:if={showCCField}>
                 <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                    <lightning-input value={ccAddresses} label="CC: Specify comma-separated e-mail addresses"
+                    <lightning-input value={ccAddresses}
+                        label={resolvedCcLabel}
+                        field-level-help={ccHelpText}
                         onchange={handleInputChange} data-field="ccAddresses">
                     </lightning-input>
                 </lightning-layout-item>
             </template>
             <template lwc:if={showBccField}>
                 <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                    <lightning-input value={bccAddresses} label="Bcc: Specify comma-separated e-mail addresses"
+                    <lightning-input value={bccAddresses}
+                        label={resolvedBccLabel}
+                        field-level-help={bccHelpText}
                         onchange={handleInputChange} data-field="bccAddresses">
                     </lightning-input>
                 </lightning-layout-item>
@@ -38,20 +44,33 @@
 
             <!-- Subject -->
             <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                <lightning-input name="subject" label="Subject" value={subject} required onchange={handleInputChange}
+                <lightning-input name="subject"
+                    label={resolvedSubjectLabel}
+                    field-level-help={subjectHelpText}
+                    value={subject} required onchange={handleInputChange}
                     data-field="subject">
                 </lightning-input>
             </lightning-layout-item>
 
-            <!-- Email Template Selection -->
-            <template if:false={hideTemplateSelection}>
+            <!-- Email Template Folder Picker -->
+            <template lwc:if={showFolderPicker}>
                 <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                    <lightning-combobox name="templateFolder" label="Select Email Template Folder:" value={selFolderId}
+                    <lightning-combobox name="templateFolder"
+                        label={resolvedFolderLabel}
+                        field-level-help={folderHelpText}
+                        value={selFolderId}
                         options={folderOptions} onchange={filterTemplatesByFolder}>
                     </lightning-combobox>
                 </lightning-layout-item>
+            </template>
+
+            <!-- Email Template Picker -->
+            <template lwc:if={showTemplatePicker}>
                 <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                    <lightning-combobox name="template" label="Select a Template:" value={selTemplateId}
+                    <lightning-combobox name="template"
+                        label={resolvedTemplateLabel}
+                        field-level-help={templateHelpText}
+                        value={selTemplateId}
                         options={filteredTemplateList} onchange={templateChanged}>
                     </lightning-combobox>
                 </lightning-layout-item>
@@ -59,11 +78,16 @@
 
             <!-- Email Body -->
             <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                <label class="slds-form-element__label">
-                    <abbr class="slds-required" title="required">*</abbr> Body
-                </label>
-                <lightning-input-rich-text label="Body" onchange={handleBodyChange}
-                    data-field="emailBody">
+                <div class="slds-grid slds-grid_vertical-align-center">
+                    <label class="slds-form-element__label">
+                        <abbr class="slds-required" title="required">*</abbr> {resolvedBodyLabel}
+                    </label>
+                    <template lwc:if={bodyHelpText}>
+                        <lightning-helptext content={bodyHelpText}></lightning-helptext>
+                    </template>
+                </div>
+                <lightning-input-rich-text label={resolvedBodyLabel}
+                    onchange={handleBodyChange} data-field="emailBody">
                 </lightning-input-rich-text>
             </lightning-layout-item>
 
@@ -89,12 +113,14 @@
                 </lightning-layout-item>
             </template>
 
-            <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
-                <label class="slds-form-element__label">Attach New Files:</label>
-                <lightning-file-upload label="" multiple record-id={uploadRefId}
-                    onuploadfinished={handleUpload_lightningFile}>
-                </lightning-file-upload>
-            </lightning-layout-item>
+            <template lwc:if={showAttachmentUploader}>
+                <lightning-layout-item size="12" class="slds-var-p-horizontal_small">
+                    <label class="slds-form-element__label">Attach New Files:</label>
+                    <lightning-file-upload label="" multiple record-id={recordId}
+                        onuploadfinished={handleUpload_lightningFile}>
+                    </lightning-file-upload>
+                </lightning-layout-item>
+            </template>
 
             <!-- Send Button -->
             <lightning-layout-item size="12" class="slds-var-p-around_small slds-text-align_center">

--- a/lwc/flowEmailComposer/flowEmailComposer.js
+++ b/lwc/flowEmailComposer/flowEmailComposer.js
@@ -25,6 +25,26 @@ export default class flowEmailComposer extends LightningElement {
     @api hideTemplateSelection = false;
     @api transitionOnSend;
     @api availableActions = [];
+    @api hideFolderPicker = false;
+    @api hideAttachments = false;
+    @api expandCcOnLoad = false;
+    @api expandBccOnLoad = false;
+    @api defaultFolderId;
+    @api bodyHeight;
+    @api toLabel;
+    @api toHelpText;
+    @api ccLabel;
+    @api ccHelpText;
+    @api bccLabel;
+    @api bccHelpText;
+    @api subjectLabel;
+    @api subjectHelpText;
+    @api bodyLabel;
+    @api bodyHelpText;
+    @api folderLabel;
+    @api folderHelpText;
+    @api templateLabel;
+    @api templateHelpText;
 
     // Properties with @track annotation for tracking changes
     @track showSpinner = false;
@@ -40,30 +60,56 @@ export default class flowEmailComposer extends LightningElement {
     @track attachmentIds = [];
     @track objFiles = [];
     @track uploadedFiles = [];
+    @track _bodyDisplay = '';
 
+    get resolvedToLabel()       { return this.toLabel       || 'To'; }
+    get resolvedCcLabel()       { return this.ccLabel       || 'CC'; }
+    get resolvedBccLabel()      { return this.bccLabel      || 'BCC'; }
+    get resolvedSubjectLabel()  { return this.subjectLabel  || 'Subject'; }
+    get resolvedBodyLabel()     { return this.bodyLabel     || 'Body'; }
+    get resolvedFolderLabel()   { return this.folderLabel   || 'Select Email Template Folder:'; }
+    get resolvedTemplateLabel() { return this.templateLabel || 'Select a Template:'; }
+
+    get showFolderPicker()       { return !this.hideTemplateSelection && !this.hideFolderPicker; }
+    get showTemplatePicker()     { return !this.hideTemplateSelection; }
+    get showAttachmentUploader() { return !this.hideAttachments; }
 
     // connectedCallback method to initialize the component
     connectedCallback() {
+        if (this.expandCcOnLoad)  this.showCCField  = true;
+        if (this.expandBccOnLoad) this.showBccField = true;
+        if (this.emailBody) this._bodyDisplay = this.emailBody;
         this.initializeComponent();
     }
 
     renderedCallback() {
+        this._applyBodyEditorSizing();
         this._syncBodyEditorValue();
         this._wireBodyEditorCursorFix();
     }
 
-    _syncBodyEditorValue() {
-        if (this.emailBody === this._lastPushedBody) return;
+    _applyBodyEditorSizing() {
         const rte = this.template.querySelector('lightning-input-rich-text');
-        if (!rte) return;
-        rte.value = this.emailBody || '';
-        this._lastPushedBody = this.emailBody;
+        if (!rte || !rte.shadowRoot) return;
+        const editable = rte.shadowRoot.querySelector('.slds-rich-text-editor__textarea');
+        if (!editable) return;
+        const h = this.bodyHeight && this.bodyHeight > 0 ? this.bodyHeight : 300;
+        if (editable.dataset.fecApplied === String(h)) return;
+        editable.style.setProperty('min-height', `${h}px`, 'important');
+        editable.style.setProperty('height', `${h}px`, 'important');
+        editable.style.setProperty('resize', 'vertical', 'important');
+        editable.style.setProperty('overflow', 'auto', 'important');
+        editable.dataset.fecApplied = String(h);
     }
 
-    // Intercept the first click into the rich-text editor so the caret lands
-    // at the click point instead of snapping to the end of the paragraph —
-    // a long-standing quirk of Quill when the editable first receives focus
-    // with pre-populated content (e.g. a default template or default body).
+    _syncBodyEditorValue() {
+        if (this._bodyDisplay === this._lastPushedBody) return;
+        const rte = this.template.querySelector('lightning-input-rich-text');
+        if (!rte) return;
+        rte.value = this._bodyDisplay || '';
+        this._lastPushedBody = this._bodyDisplay;
+    }
+
     _wireBodyEditorCursorFix() {
         const rte = this.template.querySelector('lightning-input-rich-text');
         if (!rte || !rte.shadowRoot) return;
@@ -125,15 +171,22 @@ export default class flowEmailComposer extends LightningElement {
             const root = editable.getRootNode();
             const active = root && root.activeElement;
             const hadFocus = active && (active === editable || editable.contains(active));
+            // Only intervene on the *first* click that brings focus into the editor.
+            // After that, let Quill handle clicks normally.
             if (hadFocus) return;
             if (event.button !== 0) return;
 
+            // Prevent Quill's default "focus + place caret at end of content" routine.
             event.preventDefault();
+
             const x = event.clientX;
             const y = event.clientY;
 
+            // Focus manually without scrolling, then position the caret at the click point.
             try { editable.focus({ preventScroll: true }); } catch (e) { editable.focus(); }
 
+            // Apply immediately, then again across two rAFs in case Quill still tries
+            // to reset the selection after focus settles.
             applyCaret(x, y);
             requestAnimationFrame(() => {
                 applyCaret(x, y);
@@ -147,7 +200,7 @@ export default class flowEmailComposer extends LightningElement {
     initializeComponent() {
         this.showSpinner = true;
         //Call Apex to get initial list of folders and templates
-        getEmailTemplates({ additionalCondition: this.additionalCondition, maxLimit: this.maxLimit })
+        getEmailTemplates({ folderIdFilter: this.additionalCondition, maxLimit: this.maxLimit })
             .then((templates) => {
                 const folders = [];
                 templates.forEach((template) => {
@@ -168,7 +221,15 @@ export default class flowEmailComposer extends LightningElement {
                     value: template.Id,
                     ...template,
                 }));
-                this.filteredTemplateList = [...this.allTemplates]; // Initialize with all templates                
+                this.filteredTemplateList = [...this.allTemplates]; // Initialize with all templates
+
+                if (this.defaultFolderId) {
+                    this.selFolderId = this.defaultFolderId;
+                    this.filteredTemplateList = this.allTemplates.filter(
+                        (t) => t.FolderId === this.defaultFolderId
+                    );
+                }
+
                 this.showSpinner = false;
 
                 // Check if templateId has a value and call changeBody if it does
@@ -224,6 +285,7 @@ export default class flowEmailComposer extends LightningElement {
                 // Handle the successful response
                 this.subject = result.subject;
                 this.emailBody = result.body;
+                this._bodyDisplay = result.body;
                 this.attachmentsFromTemplate = result.fileAttachments;
                 //console.log("Attachments are " + JSON.stringify(this.attachmentsFromTemplate));
 
@@ -370,6 +432,7 @@ export default class flowEmailComposer extends LightningElement {
     // Reset the form fields
     resetForm() {
         this.emailBody = '';
+        this._bodyDisplay = '';
         this.subject = '';
         this.attachmentsFromTemplate = [];
         this.selTemplateId = '';

--- a/lwc/flowEmailComposer/flowEmailComposer.js-meta.xml
+++ b/lwc/flowEmailComposer/flowEmailComposer.js-meta.xml
@@ -15,7 +15,7 @@
             <property name="fromAddress" label="From Email Address" type="String" />
             <property name="senderName" label="Sender Name" type="String"/>
             <property name="hideTemplateSelection" label="Hide Template Selection" type="Boolean"/>
-            <property name="additionalCondition" label="Additional Template Filter" type="String" description="Add additional filter criteria to return specific email templates i.e. FolderId = 'xyz'"/>
+            <property name="additionalCondition" label="Folder ID Filter" type="String" description="Filter templates by Folder Id (e.g. Unfiled Public Email Templates folder Id)"/>
             <property name="maxLimit" label="Limit of Email Templates Returned" type="Integer" description="Enter a number of Templates to return in the picker"/>
             <property name="emailTemplateId" label="Default Email Template Id" type="String"/>
             <property name="whatId" label="Related Record Id" type="String" description="Used in merge fields and activity tracking" />            
@@ -25,6 +25,26 @@
             <property name="recordId" label="Uploaded File Related Record Id" type="String"/>
             <property name="emailBody" label="Email Body" type="String"/>
             <property name="transitionOnSend" label="Navigate Flow on Send" type="Boolean" description="When true after successful email send flow will navigate to next screen or finish"/>
+            <property name="defaultFolderId" label="Default Email Template Folder Id" type="String" description="Pre-selects this folder in the folder picker on load."/>
+            <property name="hideFolderPicker" label="Hide Folder Picker Only" type="Boolean" description="Hides just the folder dropdown. Template picker remains visible. Ignored if Hide Template Selection is true."/>
+            <property name="hideAttachments" label="Hide File Attachment Uploader" type="Boolean" description="Hides the 'Attach New Files' uploader. Template-provided attachments still display."/>
+            <property name="expandCcOnLoad" label="Expand CC on Load" type="Boolean" description="Show the CC field expanded on load."/>
+            <property name="expandBccOnLoad" label="Expand BCC on Load" type="Boolean" description="Show the BCC field expanded on load."/>
+            <property name="bodyHeight" label="Body Editor Starting Height (px)" type="Integer" description="Starting height in pixels; users can drag to resize. Defaults to 300."/>
+            <property name="toLabel" label="To Field Label" type="String" description="Custom label for the To field. Defaults to 'To'."/>
+            <property name="toHelpText" label="To Field Help Text" type="String" description="Tooltip text for the To field."/>
+            <property name="ccLabel" label="CC Field Label" type="String" description="Custom label for the CC field. Defaults to 'CC'."/>
+            <property name="ccHelpText" label="CC Field Help Text" type="String" description="Tooltip text for the CC field."/>
+            <property name="bccLabel" label="BCC Field Label" type="String" description="Custom label for the BCC field. Defaults to 'BCC'."/>
+            <property name="bccHelpText" label="BCC Field Help Text" type="String" description="Tooltip text for the BCC field."/>
+            <property name="subjectLabel" label="Subject Field Label" type="String" description="Custom label for the Subject field. Defaults to 'Subject'."/>
+            <property name="subjectHelpText" label="Subject Field Help Text" type="String" description="Tooltip text for the Subject field."/>
+            <property name="bodyLabel" label="Body Field Label" type="String" description="Custom label for the Body field. Defaults to 'Body'."/>
+            <property name="bodyHelpText" label="Body Field Help Text" type="String" description="Tooltip text for the Body field."/>
+            <property name="folderLabel" label="Folder Picker Label" type="String" description="Custom label for the folder picker. Defaults to 'Select Email Template Folder:'."/>
+            <property name="folderHelpText" label="Folder Picker Help Text" type="String" description="Tooltip text for the folder picker."/>
+            <property name="templateLabel" label="Template Picker Label" type="String" description="Custom label for the template picker. Defaults to 'Select a Template:'."/>
+            <property name="templateHelpText" label="Template Picker Help Text" type="String" description="Tooltip text for the template picker."/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
## Summary

Adds a batch of new Flow-screen configuration properties and tightens the existing template filter to use a SOQL bind variable — **without breaking the existing `additionalCondition` Flow property**. Flows already in the wild using `additionalCondition` continue to work; only the label/description and internal implementation change.

## Filter property changes (non-breaking)

- **Flow property API name:** unchanged — still `additionalCondition`.
- **Label:** updated to "Folder ID Filter".
- **Description:** updated to reflect new usage — pass a Folder Id, not a raw SOQL fragment.
- **Apex implementation:** the internal parameter is renamed to `folderIdFilter` and uses a bind variable (`FolderId = :folderIdFilter`) instead of string concatenation of user input, eliminating the SOQL injection surface area.

Existing flows that pass a Folder Id (the most common use) keep working. Flows that were passing full SOQL fragments like `"DeveloperName = 'xyz'"` will no longer work; they need to be reconfigured to pass a Folder Id. That was the already-risky use case (SOQL injection).

## New Flow properties

### Visibility / layout
- `defaultFolderId` — pre-selects a template folder on load.
- `hideFolderPicker` — hides just the folder dropdown while keeping the template picker.
- `hideAttachments` — hides the "Attach New Files" uploader. Template-provided attachments still display.
- `expandCcOnLoad` / `expandBccOnLoad` — show CC / BCC fields expanded at load time.
- `bodyHeight` — starting height (px) of the rich-text editor. Drag to resize. Defaults to 300.

### Labels (override defaults)
- `toLabel`, `ccLabel`, `bccLabel`, `subjectLabel`, `bodyLabel`, `folderLabel`, `templateLabel`

### Help text (tooltips)
- `toHelpText`, `ccHelpText`, `bccHelpText`, `subjectHelpText`, `bodyHelpText`, `folderHelpText`, `templateHelpText`

Rendered as `lightning-helptext` icons next to each field label.

## Under the hood

- Added `resolved*Label` getters for graceful fallback when overrides aren't set.
- Added `_bodyDisplay` tracked property and push RTE content via `renderedCallback` (extends the imperative-value pattern introduced in #21).

## Test plan
- [x] Test `testGetEmailTemplates_WithFilter` replaced with `testGetEmailTemplates_WithFolderIdFilter`, asserting Folder-Id-scoped results.
- [x] Installed in scratch org via package version 3.0.0.1 for validation.
- [ ] Existing flow using `additionalCondition` with a Folder Id: works as before.
- [ ] Confirm the 6 visibility / layout properties behave correctly.
- [ ] Confirm label and help-text overrides render correctly.