### PR TITLE
Keep folderIdFilter alongside additionalCondition for managed-package compatibility

### DIFF
--- a/lwc/flowEmailComposer/flowEmailComposer.js
+++ b/lwc/flowEmailComposer/flowEmailComposer.js
@@ -19,6 +19,7 @@ export default class flowEmailComposer extends LightningElement {
     @api senderName;
     @api logEmail = false;
     @api additionalCondition;
+    @api folderIdFilter;
     @api recordId;
     @api emailBody;
     @api maxLimit;
@@ -200,7 +201,8 @@ export default class flowEmailComposer extends LightningElement {
     initializeComponent() {
         this.showSpinner = true;
         //Call Apex to get initial list of folders and templates
-        getEmailTemplates({ folderIdFilter: this.additionalCondition, maxLimit: this.maxLimit })
+        const filterValue = this.folderIdFilter || this.additionalCondition;
+        getEmailTemplates({ folderIdFilter: filterValue, maxLimit: this.maxLimit })
             .then((templates) => {
                 const folders = [];
                 templates.forEach((template) => {

--- a/lwc/flowEmailComposer/flowEmailComposer.js-meta.xml
+++ b/lwc/flowEmailComposer/flowEmailComposer.js-meta.xml
@@ -15,7 +15,8 @@
             <property name="fromAddress" label="From Email Address" type="String" />
             <property name="senderName" label="Sender Name" type="String"/>
             <property name="hideTemplateSelection" label="Hide Template Selection" type="Boolean"/>
-            <property name="additionalCondition" label="Folder ID Filter" type="String" description="Filter templates by Folder Id (e.g. Unfiled Public Email Templates folder Id)"/>
+            <property name="additionalCondition" label="Folder ID Filter (Legacy)" type="String" description="Legacy name for the folder filter — pass a Folder Id to restrict the template list. Prefer the newer 'Folder ID Filter' (folderIdFilter) property in new flows; this one is kept for backwards compatibility."/>
+            <property name="folderIdFilter" label="Folder ID Filter" type="String" description="Filter templates by Folder Id (e.g. Unfiled Public Email Templates folder Id). If both this and the legacy 'Folder ID Filter (Legacy)' are set, this one wins."/>
             <property name="maxLimit" label="Limit of Email Templates Returned" type="Integer" description="Enter a number of Templates to return in the picker"/>
             <property name="emailTemplateId" label="Default Email Template Id" type="String"/>
             <property name="whatId" label="Related Record Id" type="String" description="Used in merge fields and activity tracking" />            


### PR DESCRIPTION
## Summary

Follow-up to #24. The 3.0.0 managed-package release shipped with the Flow property renamed from `additionalCondition` to `folderIdFilter`, which broke flows that were already using the old property name. We can't simply remove `folderIdFilter` (managed packages don't allow removing a public `@api` property once released), so this PR exposes **both** properties and prefers `folderIdFilter` when both are set.

## Changes

- **`flowEmailComposer.js`:**
  - Re-add `@api folderIdFilter;` (kept for forward compatibility with 3.0.0).
  - Keep `@api additionalCondition;` (restores backwards compatibility with pre-3.0.0 flows).
  - Resolution rule in `initializeComponent`: use `this.folderIdFilter` if populated, otherwise fall back to `this.additionalCondition`.
- **`flowEmailComposer.js-meta.xml`:**
  - `additionalCondition` → labeled "Folder ID Filter (Legacy)" with a description explaining it's retained for backwards compatibility.
  - `folderIdFilter` → labeled "Folder ID Filter" with a description noting it wins if both are set.

## Why

- Managed-package rule: `Can't remove the following public properties: folderIdFilter, because the component is part of a managed package.` Trying to drop it fails the package version build.
- Existing flows on pre-3.0.0 subscribers were configured against `additionalCondition`; dropping it would break them on upgrade.

## Release notes

- Package version **3.0.1** ships this change.
- No breaking behavior: both property names work; if both are populated, `folderIdFilter` wins.

## Test plan
- [x] Package version 3.0.1.1 built successfully (Subscriber Package Version Id `04tDm000000cZwVIAU`).
- [ ] Install 3.0.1.1 in a sandbox; verify flows using `additionalCondition` (pre-3.0.0 style) render and filter correctly.
- [ ] Verify flows using `folderIdFilter` (3.0.0 style) continue to work.
- [ ] Verify both-populated case: `folderIdFilter` value is used.